### PR TITLE
Feature/add wartremover

### DIFF
--- a/app/adapters/error.scala
+++ b/app/adapters/error.scala
@@ -22,7 +22,7 @@ final case class InternalServerError(message: String)
 final case class NotFoundError(message: String) extends AdapterError(message)
 
 object AdapterError {
-  def fromUseCaseError(error: UseCaseError): Unit = error match {
+  def fromUseCaseError(error: UseCaseError): AdapterError = error match {
     case e: SystemError    => InternalServerError(e.getMessage)
     case e: UNotFoundError => NotFoundError(e.getMessage)
     case e: BadParamsError => BadRequestError(e.getMessage)

--- a/app/domains/post/PostRepository.scala
+++ b/app/domains/post/PostRepository.scala
@@ -1,9 +1,10 @@
 package domains.post
 
+import domains.bot.Bot.BotId
 import infra.InfraError
 
 import scala.concurrent.Future
 
 trait PostRepository {
-  def add(model: Post): Future[Unit]
+  def add(model: Post, botIds: Seq[BotId]): Future[Unit]
 }

--- a/app/usecases/RegisterPostUseCase.scala
+++ b/app/usecases/RegisterPostUseCase.scala
@@ -1,6 +1,7 @@
 package usecases
 
 import com.google.inject.Inject
+import domains.bot.Bot.BotId
 import domains.post.PostRepository
 import domains.post.Post
 import domains.post.Post._
@@ -17,7 +18,8 @@ object RegisterPostUseCase {
   final case class Params(
       url: Option[PostUrl],
       title: PostTitle,
-      postedAt: PostPostedAt
+      postedAt: PostPostedAt,
+      botIds: Seq[BotId]
   )
 }
 
@@ -28,7 +30,7 @@ final class RegisterPostUseCaseImpl @Inject()(
   override def exec(params: Params): Future[Unit] = {
     val post = Post(None, params.url, params.title, params.postedAt)
     postRepository
-      .add(post)
+      .add(post, params.botIds)
       .ifFailThenToUseCaseError(
         "error while postRepository.add in register post use case"
       )

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,10 @@ lazy val settings = Seq(
     "-language:higherKinds",
   ),
   libraryDependencies ++= rootDeps,
-  wartremoverWarnings ++= Warts.unsafe,
+  wartremoverErrors ++= Warts.unsafe,
   wartremoverExcluded ++= routes.in(Compile).value,
-  wartremoverExcluded += baseDirectory.value / "app" / "infra" / "dto"
+  wartremoverExcluded += baseDirectory.value / "app" / "infra" / "dto",
+  wartremoverExcluded += baseDirectory.value / "test"
 )
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import slick.codegen.SourceCodeGenerator
+import Dependencies._
 
 name := """TechBlogPicks"""
 organization := "com.techblogpicks"
@@ -6,6 +7,19 @@ organization := "com.techblogpicks"
 version := "1.0-SNAPSHOT"
 
 lazy val codegen = taskKey[Unit]("generate slick table code")
+
+lazy val settings = Seq(
+  scalacOptions ++= Seq(
+    "-Ymacro-annotations",
+    "-feature",
+    "-language:implicitConversions",
+    "-language:higherKinds",
+  ),
+  libraryDependencies ++= rootDeps,
+  wartremoverWarnings ++= Warts.unsafe,
+  wartremoverExcluded ++= routes.in(Compile).value,
+  wartremoverExcluded += baseDirectory.value / "app" / "infra" / "dto"
+)
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
@@ -27,44 +41,9 @@ lazy val root = (project in file("."))
       )
     }
   )
-
-scalacOptions ++= Seq(
-  "-Ymacro-annotations"
-)
+  .settings(settings)
 
 scalaVersion := "2.13.3"
-
-libraryDependencies += guice
-libraryDependencies ++= Seq(
-  "org.postgresql"       % "postgresql"             % "42.2.14",
-  "com.typesafe.play"    %% "play-slick"            % "5.0.0",
-  "com.typesafe.play"    %% "play-slick-evolutions" % "5.0.0",
-  "com.typesafe.slick"   %% "slick-codegen"         % "3.3.2",
-  evolutions
-)
-
-
-libraryDependencies ++= Seq(
-  "eu.timepit" %% "refined" % "0.9.21",
-  "eu.timepit" %% "refined-cats" % "0.9.21",
-)
-libraryDependencies += "io.estatico" %% "newtype" % "0.4.4"
-
-val circeVersion = "0.12.3"
-libraryDependencies ++= Seq(
-  "io.circe" %% "circe-core",
-  "io.circe" %% "circe-generic",
-  "io.circe" %% "circe-parser"
-).map(_ % circeVersion)
-
-libraryDependencies ++= Seq(
-  "org.scalatestplus.play"   %% "scalatestplus-play"  % "5.1.0",
-  "org.scalatestplus"        %% "scalacheck-1-14"     % "3.2.2.0",
-  "org.scalacheck"           %% "scalacheck"          % "1.15.2",
-  "org.mockito"              %% "mockito-scala"       % "1.16.29",
-).map(_ % Test)
-
-libraryDependencies += "org.typelevel" %% "cats-core" % "2.4.2"
 
 javaOptions in Runtime += "-Dconfig.file=./conf/application.dev.conf"
 envFileName in ThisBuild := ".env"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import slick.codegen.SourceCodeGenerator
 import Dependencies._
 
 name := """TechBlogPicks"""
@@ -23,24 +22,7 @@ lazy val settings = Seq(
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala)
-  .settings(
-    codegen := {
-      SourceCodeGenerator.main(
-        Array(
-          "slick.jdbc.PostgresProfile",
-          "org.postgresql.Driver",
-          "jdbc:postgresql://localhost:5432/tech_blog_picks_server",
-          "app/infra",
-          "dto",
-          sys.env.getOrElse("DB_USER", ""),
-          sys.env.getOrElse("DB_PASSWORD", ""),
-          "true",
-          "slick.codegen.SourceCodeGenerator",
-          "true"
-        )
-      )
-    }
-  )
+  .settings(codegen := CodeGenerator.gen())
   .settings(settings)
 
 scalaVersion := "2.13.3"

--- a/project/CodeGenerator.scala
+++ b/project/CodeGenerator.scala
@@ -1,0 +1,28 @@
+import sbt.file
+import slick.codegen.SourceCodeGenerator
+
+import scala.reflect.io.Directory
+
+object CodeGenerator {
+  def gen(): Unit = {
+    val directory = new Directory(file("./app/infra/dto"))
+    println(directory.isDirectory)
+    directory.deleteRecursively()
+
+    SourceCodeGenerator.main(
+      Array(
+        "slick.jdbc.PostgresProfile",
+        "org.postgresql.Driver",
+        "jdbc:postgresql://localhost:5432/tech_blog_picks_server",
+        "app/infra",
+        "infra.dto",
+        sys.env.getOrElse("DB_USER", ""),
+        sys.env.getOrElse("DB_PASSWORD", ""),
+        "true",
+        "slick.codegen.SourceCodeGenerator",
+        "true"
+      )
+    )
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,42 @@
+import play.sbt.PlayImport._
+import sbt._
+
+object Dependencies {
+  object Versions {
+    val refinedVersion = "0.9.21"
+    val circeVersion = "0.12.3"
+  }
+
+  val playDeps = Seq(guice, ws)
+
+  val dbDeps = Seq(
+    "org.postgresql" % "postgresql" % "42.2.14",
+    "com.typesafe.play" %% "play-slick" % "5.0.0",
+    "com.typesafe.play" %% "play-slick-evolutions" % "5.0.0",
+    "com.typesafe.slick" %% "slick-codegen" % "3.3.2",
+    evolutions
+  )
+
+  val testDeps = Seq(
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0",
+    "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0",
+    "org.scalacheck" %% "scalacheck" % "1.15.2",
+    "org.mockito" %% "mockito-scala" % "1.16.29"
+  ).map(_ % Test)
+
+  val refinedDeps = Seq(
+    "eu.timepit" %% "refined",
+    "eu.timepit" %% "refined-cats"
+  ).map(_ % Versions.refinedVersion)
+
+  val circeDeps = Seq(
+    "io.circe" %% "circe-core",
+    "io.circe" %% "circe-generic",
+    "io.circe" %% "circe-parser"
+  ).map(_ % Versions.circeVersion)
+
+  val newtype = "io.estatico" %% "newtype" % "0.4.4"
+  val cats = "org.typelevel" %% "cats-core" % "2.4.2"
+
+  val rootDeps = Seq(newtype, cats) ++ playDeps ++ dbDeps ++ testDeps ++ refinedDeps ++ circeDeps
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,6 @@ addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.11.0")
 addSbtPlugin("com.github.tototoshi" % "sbt-slick-codegen" % "1.4.0")
 libraryDependencies += "org.postgresql" % "postgresql" % "42.2.14"
 
-addSbtPlugin("au.com.onegeek"       %% "sbt-dotenv"       % "2.1.146")
+addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.146")
+
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")

--- a/test/domains/AccessTokenPublisherDomainSpec.scala
+++ b/test/domains/AccessTokenPublisherDomainSpec.scala
@@ -1,6 +1,6 @@
 package domains
 
-import domains.accesstokenpublisher.AccessTokenPublisher.{AccessTokenPublisherTemporaryOauthCode, AccessTokenPublisherToken}
+import domains.accesstokenpublisher.AccessTokenPublisher._
 import helpers.traits.ModelSpec
 import cats.syntax.either._
 

--- a/test/helpers/gens/domain.scala
+++ b/test/helpers/gens/domain.scala
@@ -41,10 +41,10 @@ trait PostGen {
 
 trait BotGen {
 
-  val BotIdGen: Gen[BotId] =
+  val botIdGen: Gen[BotId] =
     stringRefinedNonEmptyGen.map(BotId(_))
 
-  val BotNameGen: Gen[BotName] =
+  val botNameGen: Gen[BotName] =
     stringRefinedNonEmptyGen.map(BotName(_))
 
   val accessTokensGen: Gen[Seq[AccessTokenPublisherToken]] =
@@ -55,8 +55,8 @@ trait BotGen {
 
   val botGen: Gen[Bot] =
     for {
-      botId <- BotIdGen
-      botName <- BotNameGen
+      botId <- botIdGen
+      botName <- botNameGen
       accessTokens <- accessTokensGen
       posts <- postsGen
     } yield Bot(botId, botName, accessTokens, posts)

--- a/test/usecases/RegisterPostUseCaseSpec.scala
+++ b/test/usecases/RegisterPostUseCaseSpec.scala
@@ -18,12 +18,12 @@ class RegisterPostUseCaseSpec extends UseCaseSpec {
             val params = Params(url.some, title, postedAt)
             val post = Post(None, url.some, title, postedAt)
 
-            val _ = when(repo.add(post))
+            when(repo.add(post))
               .thenReturn(Future.unit)
 
             new RegisterPostUseCaseImpl(repo).exec(params).futureValue
 
-            val _ = verify(repo, only).add(post)
+            verify(repo, only).add(post)
             reset(repo)
         }
       }
@@ -37,7 +37,7 @@ class RegisterPostUseCaseSpec extends UseCaseSpec {
             val params = Params(url.some, title, postedAt)
             val post = Post(None, url.some, title, postedAt)
 
-            val _ = when(repo.add(post))
+            when(repo.add(post))
               .thenReturn(Future.failed(DBError("error")))
 
             val result = new RegisterPostUseCaseImpl(repo).exec(params)

--- a/test/usecases/RegisterPostUseCaseSpec.scala
+++ b/test/usecases/RegisterPostUseCaseSpec.scala
@@ -5,6 +5,7 @@ import helpers.traits.UseCaseSpec
 import usecases.RegisterPostUseCase._
 import cats.syntax.option._
 import infra.DBError
+import org.scalacheck.Gen
 
 import scala.concurrent.Future
 
@@ -13,17 +14,17 @@ class RegisterPostUseCaseSpec extends UseCaseSpec {
     "succeed" should {
       "invoked PostRepository.add once" in {
         val repo = mock[PostRepository]
-        forAll(postUrlGen, postTitleGen, postPostedAtGen) {
-          (url, title, postedAt) =>
-            val params = Params(url.some, title, postedAt)
+        forAll(postUrlGen, postTitleGen, postPostedAtGen, Gen.listOf(botIdGen)) {
+          (url, title, postedAt, botIds) =>
+            val params = Params(url.some, title, postedAt, botIds)
             val post = Post(None, url.some, title, postedAt)
 
-            when(repo.add(post))
+            when(repo.add(post, botIds))
               .thenReturn(Future.unit)
 
             new RegisterPostUseCaseImpl(repo).exec(params).futureValue
 
-            verify(repo, only).add(post)
+            verify(repo, only).add(post, botIds)
             reset(repo)
         }
       }
@@ -32,12 +33,12 @@ class RegisterPostUseCaseSpec extends UseCaseSpec {
     "failed" should {
       "throw UseCaseError" in {
         val repo = mock[PostRepository]
-        forAll(postUrlGen, postTitleGen, postPostedAtGen) {
-          (url, title, postedAt) =>
-            val params = Params(url.some, title, postedAt)
+        forAll(postUrlGen, postTitleGen, postPostedAtGen, Gen.listOf(botIdGen)) {
+          (url, title, postedAt, botIds) =>
+            val params = Params(url.some, title, postedAt, botIds)
             val post = Post(None, url.some, title, postedAt)
 
-            when(repo.add(post))
+            when(repo.add(post, botIds))
               .thenReturn(Future.failed(DBError("error")))
 
             val result = new RegisterPostUseCaseImpl(repo).exec(params)

--- a/test/usecases/RegisterPostUseCaseSpec.scala
+++ b/test/usecases/RegisterPostUseCaseSpec.scala
@@ -18,12 +18,12 @@ class RegisterPostUseCaseSpec extends UseCaseSpec {
             val params = Params(url.some, title, postedAt)
             val post = Post(None, url.some, title, postedAt)
 
-            when(repo.add(post))
+            val _ = when(repo.add(post))
               .thenReturn(Future.unit)
 
-            new RegisterPostUseCaseImpl(repo).exec(params)
+            new RegisterPostUseCaseImpl(repo).exec(params).futureValue
 
-            verify(repo, only).add(post)
+            val _ = verify(repo, only).add(post)
             reset(repo)
         }
       }
@@ -37,7 +37,7 @@ class RegisterPostUseCaseSpec extends UseCaseSpec {
             val params = Params(url.some, title, postedAt)
             val post = Post(None, url.some, title, postedAt)
 
-            when(repo.add(post))
+            val _ = when(repo.add(post))
               .thenReturn(Future.failed(DBError("error")))
 
             val result = new RegisterPostUseCaseImpl(repo).exec(params)

--- a/test/usecases/RegisterPostUseCaseSpec.scala
+++ b/test/usecases/RegisterPostUseCaseSpec.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 class RegisterPostUseCaseSpec extends UseCaseSpec {
   "exec" when {
     "succeed" should {
-      "invoked PostRepository.add once" in {
+      "invoke PostRepository.add once" in {
         val repo = mock[PostRepository]
         forAll(postUrlGen, postTitleGen, postPostedAtGen, Gen.listOf(botIdGen)) {
           (url, title, postedAt, botIds) =>


### PR DESCRIPTION
## 機能概要
wartremoverの導入
build.sbtの掃除
RegisterPostUseCaseImplの修正
PostRepositoryのAddの引数修正

## 技術的変更点概要
- [sbt公式](https://www.scala-sbt.org/1.x/docs/ja/Hello.html)を読んだ上で特に[ビルドの整理](https://www.scala-sbt.org/1.x/docs/ja/Organizing-Build.html)を参考にbuild.sbtをお掃除した
- wartremoverはunsafeに引っかかるとcompileエラーになるようにした（テストは除外）

## レビュー優先度
最速で
