### PR TITLE
Feature/fix bot domain

### DIFF
--- a/backend/app/domains/bot/Bot.scala
+++ b/backend/app/domains/bot/Bot.scala
@@ -2,7 +2,7 @@ package domains.bot
 
 import domains.EmptyStringError
 import domains.accesstokenpublisher.AccessTokenPublisher.AccessTokenPublisherToken
-import domains.bot.Bot.{BotId, BotName}
+import domains.bot.Bot.{BotClientId, BotClientSecret, BotId, BotName}
 import domains.post.Post.PostId
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
@@ -13,7 +13,9 @@ final case class Bot(
   id: BotId,
   name: BotName,
   accessTokens: Seq[AccessTokenPublisherToken],
-  posts: Seq[PostId]
+  posts: Seq[PostId],
+  clientId: Option[BotClientId],
+  clientSecret: Option[BotClientSecret]
 ) {
   def receiveToken(token: AccessTokenPublisherToken): Bot =
     this.copy(accessTokens = accessTokens :+ token)
@@ -38,4 +40,21 @@ object Bot {
       }
   }
 
+  @newtype case class BotClientId(value: String Refined NonEmpty)
+  object BotClientId {
+    def create(value: String): Either[EmptyStringError, BotClientId] =
+      refineV[NonEmpty](value) match {
+        case Left(_)  => Left(EmptyStringError("BotClientId"))
+        case Right(v) => Right(BotClientId(v))
+      }
+  }
+
+  @newtype case class BotClientSecret(value: String Refined NonEmpty)
+  object BotClientSecret {
+    def create(value: String): Either[EmptyStringError, BotClientSecret] =
+      refineV[NonEmpty](value) match {
+        case Left(_)  => Left(EmptyStringError("BotClientSecret"))
+        case Right(v) => Right(BotClientSecret(v))
+      }
+  }
 }

--- a/backend/app/domains/bot/Bot.scala
+++ b/backend/app/domains/bot/Bot.scala
@@ -19,6 +19,11 @@ final case class Bot(
 ) {
   def receiveToken(token: AccessTokenPublisherToken): Bot =
     this.copy(accessTokens = accessTokens :+ token)
+
+  def updateClientInfo(
+    clientId: Option[BotClientId],
+    clientSecret: Option[BotClientSecret]
+  ): Bot = this.copy(clientId = clientId, clientSecret = clientSecret)
 }
 
 object Bot {

--- a/backend/app/domains/bot/BotRepository.scala
+++ b/backend/app/domains/bot/BotRepository.scala
@@ -8,4 +8,5 @@ import scala.concurrent.Future
 trait BotRepository {
   def find(botId: BotId): Future[Bot]
   def update(bot: Bot, accessToken: AccessTokenPublisherToken): Future[Unit]
+  def update(bot: Bot): Future[Unit]
 }

--- a/backend/app/infra/dto/BotClientInfoTable.scala
+++ b/backend/app/infra/dto/BotClientInfoTable.scala
@@ -1,0 +1,41 @@
+package infra.dto
+// AUTO-GENERATED Slick data model for table BotClientInfo
+trait BotClientInfoTable {
+
+  self:Tables  =>
+
+  import profile.api._
+  import slick.model.ForeignKeyAction
+  // NOTE: GetResult mappers for plain SQL are only generated for tables where Slick knows how to map the types of all columns.
+  import slick.jdbc.{GetResult => GR}
+  /** Entity class storing rows of table BotClientInfo
+   *  @param botId Database column bot_id SqlType(text), PrimaryKey
+   *  @param clientId Database column client_id SqlType(text), Default(None)
+   *  @param clientSecret Database column client_secret SqlType(text), Default(None) */
+  case class BotClientInfoRow(botId: String, clientId: Option[String] = None, clientSecret: Option[String] = None)
+  /** GetResult implicit for fetching BotClientInfoRow objects using plain SQL queries */
+  implicit def GetResultBotClientInfoRow(implicit e0: GR[String], e1: GR[Option[String]]): GR[BotClientInfoRow] = GR{
+    prs => import prs._
+    BotClientInfoRow.tupled((<<[String], <<?[String], <<?[String]))
+  }
+  /** Table description of table bot_client_info. Objects of this class serve as prototypes for rows in queries. */
+  class BotClientInfo(_tableTag: Tag) extends profile.api.Table[BotClientInfoRow](_tableTag, "bot_client_info") {
+    def * = (botId, clientId, clientSecret) <> (BotClientInfoRow.tupled, BotClientInfoRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = ((Rep.Some(botId), clientId, clientSecret)).shaped.<>({r=>import r._; _1.map(_=> BotClientInfoRow.tupled((_1.get, _2, _3)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column bot_id SqlType(text), PrimaryKey */
+    val botId: Rep[String] = column[String]("bot_id", O.PrimaryKey)
+    /** Database column client_id SqlType(text), Default(None) */
+    val clientId: Rep[Option[String]] = column[Option[String]]("client_id", O.Default(None))
+    /** Database column client_secret SqlType(text), Default(None) */
+    val clientSecret: Rep[Option[String]] = column[Option[String]]("client_secret", O.Default(None))
+
+    /** Uniqueness Index over (clientId) (database name bot_client_info_client_id_key) */
+    val index1 = index("bot_client_info_client_id_key", clientId, unique=true)
+    /** Uniqueness Index over (clientSecret) (database name bot_client_info_client_secret_key) */
+    val index2 = index("bot_client_info_client_secret_key", clientSecret, unique=true)
+  }
+  /** Collection-like TableQuery object for table BotClientInfo */
+  lazy val BotClientInfo = new TableQuery(tag => new BotClientInfo(tag))
+}

--- a/backend/app/infra/dto/Tables.scala
+++ b/backend/app/infra/dto/Tables.scala
@@ -8,7 +8,7 @@ object Tables extends {
 /** Slick data model trait for extension, choice of backend or usage in the cake pattern. (Make sure to initialize this late.)
     Each generated XXXXTable trait is mixed in this trait hence allowing access to all the TableQuery lazy vals.
   */
-trait Tables extends AccessTokensTable with BotsPostsTable with PlayEvolutionsTable with PostsTable {
+trait Tables extends PlayEvolutionsTable with PostsTable with AccessTokensTable with BotsPostsTable with BotClientInfoTable {
   val profile: slick.jdbc.JdbcProfile
   import profile.api._
   import slick.model.ForeignKeyAction
@@ -16,7 +16,7 @@ trait Tables extends AccessTokensTable with BotsPostsTable with PlayEvolutionsTa
   import slick.jdbc.{GetResult => GR}
 
   /** DDL for all tables. Call .create to execute. */
-  lazy val schema: profile.SchemaDescription = AccessTokens.schema ++ BotsPosts.schema ++ PlayEvolutions.schema ++ Posts.schema
+  lazy val schema: profile.SchemaDescription = AccessTokens.schema ++ BotClientInfo.schema ++ BotsPosts.schema ++ PlayEvolutions.schema ++ Posts.schema
   @deprecated("Use .schema instead of .ddl", "3.0")
   def ddl = schema
 

--- a/backend/app/infra/syntax/domain.scala
+++ b/backend/app/infra/syntax/domain.scala
@@ -1,5 +1,6 @@
 package infra.syntax
 
+import domains.bot.Bot
 import domains.post.Post
 import infra.dto.Tables._
 
@@ -7,9 +8,10 @@ object domain extends DomainSyntax
 
 trait DomainSyntax {
   implicit final def infraSyntaxPost(model: Post): PostOps = new PostOps(model)
+  implicit final def infraSyntaxBot(model: Bot): BotOps    = new BotOps(model)
 }
 
-final private[syntax] class PostOps(private val model: Post) {
+final private[syntax] class PostOps(private val model: Post) extends AnyVal {
   def toRow(unixSec: Long): PostsRow = PostsRow(
     model.id.map(_.value.value).getOrElse(0),
     model.url.value.value,
@@ -17,5 +19,13 @@ final private[syntax] class PostOps(private val model: Post) {
     model.author.value.value,
     model.postedAt.value.value,
     unixSec
+  )
+}
+
+final private[syntax] class BotOps(private val model: Bot) extends AnyVal {
+  def toClientInfoRow: BotClientInfoRow = BotClientInfoRow(
+    model.id.value.value,
+    model.clientId.map(_.value.value),
+    model.clientSecret.map(_.value.value)
   )
 }

--- a/backend/app/usecases/UpdateBotClientInfoUseCase.scala
+++ b/backend/app/usecases/UpdateBotClientInfoUseCase.scala
@@ -1,0 +1,43 @@
+package usecases
+
+import com.google.inject.Inject
+import domains.bot.Bot._
+import domains.bot.BotRepository
+import usecases.UpdateBotClientInfoUseCase._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait UpdateBotClientInfoUseCase {
+  def exec(params: Params): Future[Unit]
+}
+
+object UpdateBotClientInfoUseCase {
+  final case class Params(
+    botId: BotId,
+    botClientId: Option[BotClientId],
+    botClientSecret: Option[BotClientSecret]
+  )
+}
+
+final class UpdateBotClientUseCaseImpl @Inject() (botRepository: BotRepository)(
+  implicit val ec: ExecutionContext
+) extends UpdateBotClientInfoUseCase {
+  override def exec(params: Params): Future[Unit] = for {
+    bot <-
+      botRepository
+        .find(params.botId)
+        .ifFailThenToUseCaseError(
+          "error while botRepository.find in update bot client info use case"
+        )
+
+    updatedBot =
+      bot.updateClientInfo(params.botClientId, params.botClientSecret)
+
+    _ <-
+      botRepository
+        .update(updatedBot)
+        .ifFailThenToUseCaseError(
+          "error while botRepository.update in update bot client info use case"
+        )
+  } yield ()
+}

--- a/backend/conf/evolutions/default/1.sql
+++ b/backend/conf/evolutions/default/1.sql
@@ -22,6 +22,13 @@ CREATE TABLE public.bots_posts
     post_id BIGINT NOT NULL REFERENCES posts(id)
 );
 
+CREATE TABLE public.bot_client_info
+(
+    bot_id TEXT PRIMARY KEY,
+    client_id TEXT UNIQUE,
+    client_secret TEXT UNIQUE
+);
+
 -- !Downs
 DROP TABLE public.access_tokens CASCADE;
 DROP TABLE public.posts CASCADE;

--- a/backend/test/domains/BotDomainSpec.scala
+++ b/backend/test/domains/BotDomainSpec.scala
@@ -2,7 +2,6 @@ package domains
 
 import domains.bot.Bot._
 import helpers.traits.ModelSpec
-import cats.syntax.either._
 
 class BotDomainSpec extends ModelSpec {
   "BotId.create" when {
@@ -10,7 +9,7 @@ class BotDomainSpec extends ModelSpec {
       "return Right value which equals given arg value" in {
         forAll(stringRefinedNonEmptyGen) { str =>
           val result = BotId.create(str.value)
-          assert(result.map(_.value) == str.asRight)
+          assert(result.map(_.value) === Right(str))
         }
       }
     }
@@ -18,7 +17,7 @@ class BotDomainSpec extends ModelSpec {
     "given empty string" should {
       "return Left value which values equals DomainError" in {
         val result = BotId.create("")
-        assert(result.leftSide == EmptyStringError("BotId").asLeft)
+        assert(result.leftSide === Left(EmptyStringError("BotId")))
       }
     }
   }
@@ -28,7 +27,7 @@ class BotDomainSpec extends ModelSpec {
       "return Right value which equals given arg value" in {
         forAll(stringRefinedNonEmptyGen) { str =>
           val result = BotName.create(str.value)
-          assert(result.map(_.value) == str.asRight)
+          assert(result.map(_.value) === Right(str))
         }
       }
     }
@@ -36,7 +35,43 @@ class BotDomainSpec extends ModelSpec {
     "given empty string" should {
       "return Left value which values equals DomainError" in {
         val result = BotName.create("")
-        assert(result.leftSide == EmptyStringError("BotName").asLeft)
+        assert(result.leftSide === Left(EmptyStringError("BotName")))
+      }
+    }
+  }
+
+  "BotClientId.create" when {
+    "given non-empty string" should {
+      "return Right value which equals given arg value" in {
+        forAll(stringRefinedNonEmptyGen) { str =>
+          val result = BotClientId.create(str.value)
+          assert(result.map(_.value) === Right(str))
+        }
+      }
+    }
+
+    "given empty string" should {
+      "return Left value which values equals DomainError" in {
+        val result = BotClientId.create("")
+        assert(result.leftSide === Left(EmptyStringError("BotClientId")))
+      }
+    }
+  }
+
+  "BotClientSecret.create" when {
+    "given non-empty string" should {
+      "return Right value which equals given arg value" in {
+        forAll(stringRefinedNonEmptyGen) { str =>
+          val result = BotClientSecret.create(str.value)
+          assert(result.map(_.value) === Right(str))
+        }
+      }
+    }
+
+    "given empty string" should {
+      "return Left value which values equals DomainError" in {
+        val result = BotClientSecret.create("")
+        assert(result.leftSide === Left(EmptyStringError("BotClientSecret")))
       }
     }
   }
@@ -48,9 +83,9 @@ class BotDomainSpec extends ModelSpec {
           model
             .receiveToken(token)
             .accessTokens
-            .size == model.accessTokens.size + 1
+            .size === model.accessTokens.size + 1
         )
-        assert(model.receiveToken(token).accessTokens.last == token)
+        assert(model.receiveToken(token).accessTokens.last === token)
       }
     }
   }

--- a/backend/test/domains/BotDomainSpec.scala
+++ b/backend/test/domains/BotDomainSpec.scala
@@ -2,6 +2,7 @@ package domains
 
 import domains.bot.Bot._
 import helpers.traits.ModelSpec
+import org.scalacheck.Gen
 
 class BotDomainSpec extends ModelSpec {
   "BotId.create" when {
@@ -86,6 +87,21 @@ class BotDomainSpec extends ModelSpec {
             .size === model.accessTokens.size + 1
         )
         assert(model.receiveToken(token).accessTokens.last === token)
+      }
+    }
+  }
+
+  "Bot.updateClientInfo" should {
+    "return Bot model which client info updated" in {
+      forAll(
+        botGen,
+        Gen.option(botClientIdGen),
+        Gen.option(botClientSecretGen)
+      ) { (model, id, secret) =>
+        val result = model.updateClientInfo(id, secret)
+
+        assert(result.clientId === id)
+        assert(result.clientSecret === secret)
       }
     }
   }

--- a/backend/test/helpers/gens/domain.scala
+++ b/backend/test/helpers/gens/domain.scala
@@ -61,10 +61,18 @@ trait BotGen {
   val accessTokensGen: Gen[Seq[AccessTokenPublisherToken]] =
     Gen.listOf(domain.accessTokenGen)
 
+  val botClientIdGen: Gen[BotClientId] =
+    stringRefinedNonEmptyGen.map(BotClientId(_))
+
+  val botClientSecretGen: Gen[BotClientSecret] =
+    stringRefinedNonEmptyGen.map(BotClientSecret(_))
+
   val botGen: Gen[Bot] = for {
     botId        <- botIdGen
     botName      <- botNameGen
     accessTokens <- accessTokensGen
     posts        <- Gen.listOf(postIdGen)
-  } yield Bot(botId, botName, accessTokens, posts)
+    clientId     <- Gen.option(botClientIdGen)
+    clientSecret <- Gen.option(botClientSecretGen)
+  } yield Bot(botId, botName, accessTokens, posts, clientId, clientSecret)
 }

--- a/backend/test/infra/repositories/BotRepositoryImplSpec.scala
+++ b/backend/test/infra/repositories/BotRepositoryImplSpec.scala
@@ -3,7 +3,7 @@ package infra.repositories
 import domains.accesstokenpublisher.AccessTokenPublisher.AccessTokenPublisherToken
 import play.api.mvc.Results.Ok
 import domains.bot.{Bot, BotRepository}
-import domains.bot.Bot.{BotId, BotName}
+import domains.bot.Bot.{BotClientId, BotClientSecret, BotId, BotName}
 import domains.post.Post.PostId
 import helpers.traits.{HasDB, RepositorySpec}
 import infra.dto.Tables._
@@ -14,7 +14,8 @@ import play.api.Application
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import eu.timepit.refined.auto._
-import infra.dto.Tables
+import cats.syntax.option._
+import org.scalatest.time.{Millis, Span}
 
 trait BotRepositoryImplSpecContext { this: HasDB =>
   val beforeAction = DBIO
@@ -41,11 +42,15 @@ trait BotRepositoryImplSpecContext { this: HasDB =>
           BotsPostsRow(4, "bot2", 1),
           BotsPostsRow(5, "bot3", 3)
         )
+      ),
+      BotClientInfo.forceInsertAll(
+        Seq(BotClientInfoRow("bot1", "clientId".some, "clientSecret".some))
       )
     )
     .transactionally
 
-  val deleteAction = BotsPosts.delete >> Posts.delete >> AccessTokens.delete
+  val deleteAction =
+    BotsPosts.delete >> Posts.delete >> AccessTokens.delete >> BotClientInfo.delete
 
   val paramBotId = BotId("bot1")
 
@@ -80,8 +85,8 @@ class BotRepositoryImplSuccessSpec
               AccessTokenPublisherToken("token2")
             ),
             Seq(PostId(1L), PostId(2L), PostId(3L)),
-            None,
-            None
+            BotClientId("clientId").some,
+            BotClientSecret("clientSecret").some
           )
         )
       }
@@ -127,6 +132,46 @@ class BotRepositoryImplSuccessSpec
       }
     }
   }
+
+  "update" when {
+    "client info does not exist" should {
+      "insert new record" in {
+        forAll(botGen) { model =>
+          val updated = model.copy(id = BotId("bot2"))
+          repository.update(updated).futureValue
+
+          val result =
+            db.run(BotClientInfo.filter(_.botId === "bot2").result).futureValue
+
+          assert(result.length === 1)
+          assert(result.head.clientId === updated.clientId.map(_.value.value))
+          assert(
+            result.head.clientSecret === updated.clientSecret.map(_.value.value)
+          )
+
+          db.run(BotClientInfo.filter(_.botId === "bot2").delete).futureValue
+        }
+      }
+    }
+
+    "client info has already exist" should {
+      "update record" in {
+        forAll(botGen) { model =>
+          val updated = model.copy(id = BotId("bot1"))
+          repository.update(updated).futureValue
+
+          val result =
+            db.run(BotClientInfo.filter(_.botId === "bot1").result).futureValue
+
+          assert(result.length === 1)
+          assert(result.head.clientId === updated.clientId.map(_.value.value))
+          assert(
+            result.head.clientSecret === updated.clientSecret.map(_.value.value)
+          )
+        }
+      }
+    }
+  }
 }
 
 class BotRepositoryImplFailSpec
@@ -139,6 +184,9 @@ class BotRepositoryImplFailSpec
 
   override val app: Application =
     builder.overrides(bind[WSClient].toInstance(mockWs)).build()
+
+  implicit val conf: PatienceConfig =
+    PatienceConfig(scaled(Span(500, Millis)), scaled(Span(15, Millis)))
 
   before(db.run(beforeAction).futureValue)
   after(db.run(deleteAction).ready())
@@ -155,6 +203,50 @@ class BotRepositoryImplFailSpec
                     |""".stripMargin.trim
 
         whenReady(result.failed)(e => assert(e.getMessage.trim == msg))
+      }
+    }
+  }
+
+  "update" when {
+    "insert existing client id" should {
+      "return error" in {
+        forAll(botGen) { model =>
+          val updated = model
+            .copy(id = BotId("bot2"), clientId = BotClientId("clientId").some)
+
+          val result = repository.update(updated)
+
+          val msg = """
+              |DBError
+              |error while BotRepository.update
+              |ERROR: 重複したキー値は一意性制約"bot_client_info_client_id_key"違反となります
+              |  詳細: キー (client_id)=(clientId) はすでに存在します。
+              |""".stripMargin.trim
+
+          whenReady(result.failed)(e => assert(e.getMessage.trim === msg))
+        }
+      }
+    }
+
+    "insert existing client secret" should {
+      "return error" in {
+        forAll(botGen) { model =>
+          val updated = model.copy(
+            id = BotId("bot2"),
+            clientSecret = BotClientSecret("clientSecret").some
+          )
+
+          val result = repository.update(updated)
+
+          val msg = """
+                      |DBError
+                      |error while BotRepository.update
+                      |ERROR: 重複したキー値は一意性制約"bot_client_info_client_secret_key"違反となります
+                      |  詳細: キー (client_secret)=(clientSecret) はすでに存在します。
+                      |""".stripMargin.trim
+
+          whenReady(result.failed)(e => assert(e.getMessage.trim === msg))
+        }
       }
     }
   }

--- a/backend/test/infra/repositories/BotRepositoryImplSpec.scala
+++ b/backend/test/infra/repositories/BotRepositoryImplSpec.scala
@@ -79,7 +79,9 @@ class BotRepositoryImplSuccessSpec
               AccessTokenPublisherToken("token1"),
               AccessTokenPublisherToken("token2")
             ),
-            Seq(PostId(1L), PostId(2L), PostId(3L))
+            Seq(PostId(1L), PostId(2L), PostId(3L)),
+            None,
+            None
           )
         )
       }

--- a/backend/test/usecases/UpdateBotClientInfoUseCaseSpec.scala
+++ b/backend/test/usecases/UpdateBotClientInfoUseCaseSpec.scala
@@ -1,0 +1,101 @@
+package usecases
+
+import domains.bot.BotRepository
+import helpers.traits.UseCaseSpec
+import infra.DBError
+import org.scalacheck.Gen
+import usecases.UpdateBotClientInfoUseCase._
+
+import scala.concurrent.Future
+
+class UpdateBotClientInfoUseCaseSpec extends UseCaseSpec {
+  val repo = mock[BotRepository]
+
+  "exec" when {
+    "succeed" should {
+      "invoke BotRepository.find & update once" in {
+        forAll(
+          botGen,
+          Gen.option(botClientIdGen),
+          Gen.option(botClientSecretGen)
+        ) { (model, clientId, secret) =>
+          val params  = Params(model.id, clientId, secret)
+          val updated = model.updateClientInfo(clientId, secret)
+
+          when(repo.find(model.id)).thenReturn(Future.successful(model))
+          when(repo.update(updated)).thenReturn(Future.unit)
+
+          new UpdateBotClientUseCaseImpl(repo).exec(params).futureValue
+
+          verify(repo).find(model.id)
+          verify(repo).update(updated)
+
+          reset(repo)
+        }
+      }
+    }
+
+    "find failed" should {
+      "return UseCaseError & never invoke update" in {
+        forAll(
+          botGen,
+          Gen.option(botClientIdGen),
+          Gen.option(botClientSecretGen)
+        ) { (model, clientId, secret) =>
+          val params  = Params(model.id, clientId, secret)
+          val updated = model.updateClientInfo(clientId, secret)
+
+          when(repo.find(model.id)).thenReturn(Future.failed(DBError("error")))
+
+          val result = new UpdateBotClientUseCaseImpl(repo).exec(params)
+
+          val msg = """
+              |SystemError
+              |error while botRepository.find in update bot client info use case
+              |DBError
+              |error
+              |""".stripMargin.trim
+
+          whenReady(result.failed)(e => assert(e.getMessage.trim === msg))
+
+          verify(repo, never).update(updated)
+
+          reset(repo)
+        }
+      }
+    }
+
+    "update failed" should {
+      "return UseCaseError & invoke BotRepository.find & update once" in {
+        forAll(
+          botGen,
+          Gen.option(botClientIdGen),
+          Gen.option(botClientSecretGen)
+        ) { (model, clientId, secret) =>
+          val params  = Params(model.id, clientId, secret)
+          val updated = model.updateClientInfo(clientId, secret)
+
+          when(repo.find(model.id)).thenReturn(Future.successful(model))
+          when(repo.update(updated)).thenReturn(Future.failed(DBError("error")))
+
+          val result = new UpdateBotClientUseCaseImpl(repo).exec(params)
+
+          val msg = """
+              |SystemError
+              |error while botRepository.update in update bot client info use case
+              |DBError
+              |error
+              |""".stripMargin.trim
+
+          whenReady(result.failed) { e =>
+            verify(repo).find(model.id)
+            verify(repo).update(updated)
+            assert(e.getMessage.trim === msg)
+          }
+
+          reset(repo)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 機能概要
clientの情報をbotと紐付ける機能のドメイン、ユースケース、インフラの実装と各テスト
dbスキーマの修正
codegen

## 技術的変更点概要
- bot_client_infoテーブルの追加
- botにclient情報を更新するメソッドを追加

## 特にレビューをお願いしたい箇所
domain、usecase、infraImplの実装部分
テスト
スキーマは軽く

## レビュー優先度
最速で

