### PR TITLE
Feature/fix access token find

### DIFF
--- a/backend/app/domains/accesstokenpublisher/AccessTokenPublisherRepository.scala
+++ b/backend/app/domains/accesstokenpublisher/AccessTokenPublisherRepository.scala
@@ -1,11 +1,14 @@
 package domains.accesstokenpublisher
 
 import domains.accesstokenpublisher.AccessTokenPublisher.AccessTokenPublisherTemporaryOauthCode
+import domains.bot.Bot.{BotClientId, BotClientSecret}
 
 import scala.concurrent.Future
 
 trait AccessTokenPublisherRepository {
   def find(
-    code: AccessTokenPublisherTemporaryOauthCode
+    code: AccessTokenPublisherTemporaryOauthCode,
+    clientId: BotClientId,
+    clientSecret: BotClientSecret
   ): Future[Option[AccessTokenPublisher]]
 }

--- a/backend/app/infra/repositoryimpl/AccessTokenPublisherRepositoryImpl.scala
+++ b/backend/app/infra/repositoryimpl/AccessTokenPublisherRepositoryImpl.scala
@@ -6,6 +6,7 @@ import domains.accesstokenpublisher.{
   AccessTokenPublisher,
   AccessTokenPublisherRepository
 }
+import domains.bot.Bot.{BotClientId, BotClientSecret}
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.libs.ws._
 import slick.jdbc.PostgresProfile
@@ -13,6 +14,7 @@ import slick.jdbc.PostgresProfile.API
 import infra.format.AccessTokenPublisherTokenDecoder
 import io.circe.parser._
 import infra.syntax.all._
+import infra.dto.Tables._
 import io.circe.Json
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -25,7 +27,9 @@ class AccessTokenPublisherRepositoryImpl @Inject() (
     with AccessTokenPublisherRepository with API
     with AccessTokenPublisherTokenDecoder {
   override def find(
-    code: AccessTokenPublisher.AccessTokenPublisherTemporaryOauthCode
+    code: AccessTokenPublisher.AccessTokenPublisherTemporaryOauthCode,
+    clientId: BotClientId,
+    clientSecret: BotClientSecret
   ): Future[Option[AccessTokenPublisher]] = {
     val oauthURL = "https://slack.com/api/oauth.v2.access"
 
@@ -33,8 +37,8 @@ class AccessTokenPublisherRepositoryImpl @Inject() (
       resp <- ws.url(oauthURL)
                 .withQueryStringParameters(
                   "code"          -> code.value.value,
-                  "client_id"     -> "1857273131876.1857349108100",
-                  "client_secret" -> "ce17821a5d59928d7b2cd433502c6eee"
+                  "client_id"     -> clientId.value.value,
+                  "client_secret" -> clientSecret.value.value
                 )
                 .post(Json.Null.noSpaces)
                 .ifFailedThenToInfraError(s"error while posting $oauthURL")

--- a/backend/app/usecases/ops/OptionOps.scala
+++ b/backend/app/usecases/ops/OptionOps.scala
@@ -1,0 +1,14 @@
+package usecases.ops
+
+import usecases.SystemError
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait OptionOps {
+  implicit class OptionTOps[T](private val option: Option[T]) {
+    def ifNotExistsToUseCaseError(message: String): Future[T] = option match {
+      case Some(v) => Future.successful(v)
+      case None    => Future.failed(SystemError(message))
+    }
+  }
+}

--- a/backend/app/usecases/package.scala
+++ b/backend/app/usecases/package.scala
@@ -1,3 +1,3 @@
-import usecases.ops.FutureOps
+import usecases.ops.{FutureOps, OptionOps}
 
-package object usecases extends FutureOps
+package object usecases extends FutureOps with OptionOps

--- a/backend/test/helpers/gens/domain.scala
+++ b/backend/test/helpers/gens/domain.scala
@@ -75,4 +75,7 @@ trait BotGen {
     clientId     <- Gen.option(botClientIdGen)
     clientSecret <- Gen.option(botClientSecretGen)
   } yield Bot(botId, botName, accessTokens, posts, clientId, clientSecret)
+
+  val nonOptionBotGen: Gen[Bot] =
+    botGen.suchThat(bot => bot.clientId.isDefined && bot.clientSecret.isDefined)
 }

--- a/backend/test/infra/repositories/AccessTokenPublisherRepositoryImplSpec.scala
+++ b/backend/test/infra/repositories/AccessTokenPublisherRepositoryImplSpec.scala
@@ -34,17 +34,19 @@ class AccessTokenPublisherRepositoryImplSuccessSpec
   "find" when {
     "succeed" should {
       "get access token" in {
-        forAll(temporaryOauthCodeGen) { code =>
-          val result = repository.find(code).futureValue
+        forAll(temporaryOauthCodeGen, botClientIdGen, botClientSecretGen) {
+          (code, clientId, clientSecret) =>
+            val result =
+              repository.find(code, clientId, clientSecret).futureValue
 
-          assert(
-            result === Some(
-              AccessTokenPublisher(
-                AccessTokenPublisherToken("mock access token"),
-                code
+            assert(
+              result === Some(
+                AccessTokenPublisher(
+                  AccessTokenPublisherToken("mock access token"),
+                  code
+                )
               )
             )
-          )
         }
       }
     }
@@ -56,12 +58,13 @@ class AccessTokenPublisherRepositoryImplFailSpec
   "find" when {
     "failed" should {
       "None returned" in {
-        forAll(temporaryOauthCodeGen) { code =>
-          val result = repository.find(code)
+        forAll(temporaryOauthCodeGen, botClientIdGen, botClientSecretGen) {
+          (code, clientId, clientSecret) =>
+            val result = repository.find(code, clientId, clientSecret)
 
-          whenReady(result, timeout(Span(1, Seconds))) { e =>
-            assert(e === None)
-          }
+            whenReady(result, timeout(Span(1, Seconds))) { e =>
+              assert(e === None)
+            }
         }
       }
     }

--- a/backend/test/usecases/InstallBotUseCaseSpec.scala
+++ b/backend/test/usecases/InstallBotUseCaseSpec.scala
@@ -1,10 +1,12 @@
 package usecases
 
 import domains.accesstokenpublisher.AccessTokenPublisherRepository
-import domains.bot.BotRepository
+import domains.bot.Bot.{BotClientId, BotClientSecret}
+import domains.bot.{Bot, BotRepository}
 import helpers.traits.UseCaseSpec
 import usecases.InstallBotUseCase._
 import infra.DBError
+import eu.timepit.refined.auto._
 
 import scala.concurrent.Future
 
@@ -14,52 +16,108 @@ class InstallBotUseCaseSpec extends UseCaseSpec {
     val botRepo         = mock[BotRepository]
     "succeed" should {
       "invoke botRepository.find once & accessTokenPublisherRepository.find once & botRepository.update once" in {
-        forAll(temporaryOauthCodeGen, botGen, accessTokenPublisherGen) {
-          (tempOauthCode, bot, accessTokenPublisher) =>
-            val params = Params(tempOauthCode, bot.id)
+        forAll(
+          temporaryOauthCodeGen,
+          nonOptionBotGen,
+          accessTokenPublisherGen
+        ) { (tempOauthCode, bot, accessTokenPublisher) =>
+          val params = Params(tempOauthCode, bot.id)
 
-            when(botRepo.find(params.botId)).thenReturn(Future.successful(bot))
-            when(accessTokenRepo.find(params.temporaryOauthCode))
-              .thenReturn(Future.successful(Some(accessTokenPublisher)))
-            when(
-              botRepo.update(
-                bot.receiveToken(accessTokenPublisher.publishToken),
-                accessTokenPublisher.publishToken
-              )
-            ).thenReturn(Future.unit)
-
-            new InstallBotUseCaseImpl(accessTokenRepo, botRepo)
-              .exec(params)
-              .futureValue
-
-            verify(botRepo).find(params.botId)
-            verify(accessTokenRepo, only).find(params.temporaryOauthCode)
-            verify(botRepo).update(
+          when(botRepo.find(params.botId)).thenReturn(Future.successful(bot))
+          when(
+            accessTokenRepo.find(
+              params.temporaryOauthCode,
+              bot.clientId.get,
+              bot.clientSecret.get
+            )
+          ).thenReturn(Future.successful(Some(accessTokenPublisher)))
+          when(
+            botRepo.update(
               bot.receiveToken(accessTokenPublisher.publishToken),
               accessTokenPublisher.publishToken
             )
-            reset(accessTokenRepo)
-            reset(botRepo)
+          ).thenReturn(Future.unit)
+
+          new InstallBotUseCaseImpl(accessTokenRepo, botRepo)
+            .exec(params)
+            .futureValue
+
+          verify(botRepo).find(params.botId)
+          verify(accessTokenRepo, only).find(
+            params.temporaryOauthCode,
+            bot.clientId.get,
+            bot.clientSecret.get
+          )
+          verify(botRepo).update(
+            bot.receiveToken(accessTokenPublisher.publishToken),
+            accessTokenPublisher.publishToken
+          )
+          reset(accessTokenRepo)
+          reset(botRepo)
         }
       }
     }
 
     "failed in botRepository.find" should {
       "throw use case error and not invoked accessTokenPublisherRepository.find & botRepository.update" in {
+        forAll(
+          temporaryOauthCodeGen,
+          nonOptionBotGen,
+          accessTokenPublisherGen
+        ) { (tempOauthCode, bot, accessTokenPublisher) =>
+          val params = Params(tempOauthCode, bot.id)
+
+          when(botRepo.find(params.botId))
+            .thenReturn(Future.failed(DBError("error")))
+          when(
+            accessTokenRepo.find(
+              params.temporaryOauthCode,
+              bot.clientId.get,
+              bot.clientSecret.get
+            )
+          ).thenReturn(Future.successful(Some(accessTokenPublisher)))
+          when(
+            botRepo.update(
+              bot.receiveToken(accessTokenPublisher.publishToken),
+              accessTokenPublisher.publishToken
+            )
+          ).thenReturn(Future.unit)
+
+          val result =
+            new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
+
+          whenReady(result.failed) { e =>
+            assert(
+              e === SystemError(
+                "error while botRepository.find in install bot use case" + "\n"
+                  + DBError("error").getMessage
+              )
+            )
+            verify(accessTokenRepo, never).find(
+              params.temporaryOauthCode,
+              bot.clientId.get,
+              bot.clientSecret.get
+            )
+            verify(botRepo, never).update(
+              bot.receiveToken(accessTokenPublisher.publishToken),
+              accessTokenPublisher.publishToken
+            )
+          }
+        }
+      }
+    }
+
+    "returned clientId which is None" should {
+      "throw use case error and not invoked accessTokenPublisherRepository.find and botRepository.update" in {
         forAll(temporaryOauthCodeGen, botGen, accessTokenPublisherGen) {
           (tempOauthCode, bot, accessTokenPublisher) =>
             val params = Params(tempOauthCode, bot.id)
 
-            when(botRepo.find(params.botId))
-              .thenReturn(Future.failed(DBError("error")))
-            when(accessTokenRepo.find(params.temporaryOauthCode))
-              .thenReturn(Future.successful(Some(accessTokenPublisher)))
-            when(
-              botRepo.update(
-                bot.receiveToken(accessTokenPublisher.publishToken),
-                accessTokenPublisher.publishToken
+            when(botRepo.find(params.botId)).thenReturn(
+              Future.successful(
+                bot.updateClientInfo(None, Some(BotClientSecret("test")))
               )
-            ).thenReturn(Future.unit)
+            )
 
             val result =
               new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
@@ -67,14 +125,34 @@ class InstallBotUseCaseSpec extends UseCaseSpec {
             whenReady(result.failed) { e =>
               assert(
                 e === SystemError(
-                  "error while botRepository.find in install bot use case" + "\n"
-                    + DBError("error").getMessage
+                  "error while get bot client id in install bot use case"
                 )
               )
-              verify(accessTokenRepo, never).find(params.temporaryOauthCode)
-              verify(botRepo, never).update(
-                bot.receiveToken(accessTokenPublisher.publishToken),
-                accessTokenPublisher.publishToken
+            }
+        }
+      }
+    }
+
+    "returned clientSecret which is None" should {
+      "throw use case error and not invoked accessTokenPublisherRepository.find and botRepository.update" in {
+        forAll(temporaryOauthCodeGen, botGen, accessTokenPublisherGen) {
+          (tempOauthCode, bot, accessTokenPublisher) =>
+            val params = Params(tempOauthCode, bot.id)
+
+            when(botRepo.find(params.botId)).thenReturn(
+              Future.successful(
+                bot.updateClientInfo(Some(BotClientId("test")), None)
+              )
+            )
+
+            val result =
+              new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
+
+            whenReady(result.failed) { e =>
+              assert(
+                e === SystemError(
+                  "error while get bot client secret in install bot use case"
+                )
               )
             }
         }
@@ -83,65 +161,81 @@ class InstallBotUseCaseSpec extends UseCaseSpec {
 
     "failed in accessTokenPublisherRepository.find" should {
       "throw use case error and not invoked botRepository.update" in {
-        forAll(temporaryOauthCodeGen, botGen, accessTokenPublisherGen) {
-          (tempOauthCode, bot, accessTokenPublisher) =>
-            val params = Params(tempOauthCode, bot.id)
+        forAll(
+          temporaryOauthCodeGen,
+          nonOptionBotGen,
+          accessTokenPublisherGen
+        ) { (tempOauthCode, bot, accessTokenPublisher) =>
+          val params = Params(tempOauthCode, bot.id)
 
-            when(botRepo.find(params.botId)).thenReturn(Future.successful(bot))
-            when(accessTokenRepo.find(params.temporaryOauthCode))
-              .thenReturn(Future.successful(None))
-            when(
-              botRepo.update(
-                bot.receiveToken(accessTokenPublisher.publishToken),
-                accessTokenPublisher.publishToken
-              )
-            ).thenReturn(Future.unit)
+          when(botRepo.find(params.botId)).thenReturn(Future.successful(bot))
+          when(
+            accessTokenRepo.find(
+              params.temporaryOauthCode,
+              bot.clientId.get,
+              bot.clientSecret.get
+            )
+          ).thenReturn(Future.successful(None))
+          when(
+            botRepo.update(
+              bot.receiveToken(accessTokenPublisher.publishToken),
+              accessTokenPublisher.publishToken
+            )
+          ).thenReturn(Future.unit)
 
-            val result =
-              new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
+          val result =
+            new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
 
-            whenReady(result.failed) { e =>
-              assert(
-                e === NotFoundError(
-                  "error while accessTokenPublisherRepository.find in install bot use case"
-                )
+          whenReady(result.failed) { e =>
+            assert(
+              e === NotFoundError(
+                "error while accessTokenPublisherRepository.find in install bot use case"
               )
-              verify(botRepo, never).update(
-                bot.receiveToken(accessTokenPublisher.publishToken),
-                accessTokenPublisher.publishToken
-              )
-            }
+            )
+            verify(botRepo, never).update(
+              bot.receiveToken(accessTokenPublisher.publishToken),
+              accessTokenPublisher.publishToken
+            )
+          }
         }
       }
     }
 
     "failed in botRepository.update" should {
       "throw use case error" in {
-        forAll(temporaryOauthCodeGen, botGen, accessTokenPublisherGen) {
-          (tempOauthCode, bot, accessTokenPublisher) =>
-            val params = Params(tempOauthCode, bot.id)
+        forAll(
+          temporaryOauthCodeGen,
+          nonOptionBotGen,
+          accessTokenPublisherGen
+        ) { (tempOauthCode, bot, accessTokenPublisher) =>
+          val params = Params(tempOauthCode, bot.id)
 
-            when(botRepo.find(params.botId)).thenReturn(Future.successful(bot))
-            when(accessTokenRepo.find(params.temporaryOauthCode))
-              .thenReturn(Future.successful(Some(accessTokenPublisher)))
-            when(
-              botRepo.update(
-                bot.receiveToken(accessTokenPublisher.publishToken),
-                accessTokenPublisher.publishToken
+          when(botRepo.find(params.botId)).thenReturn(Future.successful(bot))
+          when(
+            accessTokenRepo.find(
+              params.temporaryOauthCode,
+              bot.clientId.get,
+              bot.clientSecret.get
+            )
+          ).thenReturn(Future.successful(Some(accessTokenPublisher)))
+          when(
+            botRepo.update(
+              bot.receiveToken(accessTokenPublisher.publishToken),
+              accessTokenPublisher.publishToken
+            )
+          ).thenReturn(Future.failed(DBError("error")))
+
+          val result =
+            new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
+
+          whenReady(result.failed) { e =>
+            assert(
+              e === SystemError(
+                "error while botRepository.update in install bot use case" + "\n"
+                  + DBError("error").getMessage
               )
-            ).thenReturn(Future.failed(DBError("error")))
-
-            val result =
-              new InstallBotUseCaseImpl(accessTokenRepo, botRepo).exec(params)
-
-            whenReady(result.failed) { e =>
-              assert(
-                e === SystemError(
-                  "error while botRepository.update in install bot use case" + "\n"
-                    + DBError("error").getMessage
-                )
-              )
-            }
+            )
+          }
         }
       }
     }


### PR DESCRIPTION
## 機能概要
access token publisherのfind修正
上記findでclient_idやsecretがない場合のハンドリングをinstall bot usecaseに実装

## レビュー優先度
最速

