### PR TITLE
リダイレクト先のurlを正式なものに変更

### DIFF
--- a/backend/app/adapters/controllers/bot/BotController.scala
+++ b/backend/app/adapters/controllers/bot/BotController.scala
@@ -60,10 +60,10 @@ class BotController @Inject() (
               .exec(Params(tuple._1, tuple._2))
               .transformWith[Result]({
                 case Success(_) =>
-                  Future.successful(Redirect("https://google.com"))
+                  Future.successful(Redirect("https://winkie.app/success"))
                 case Failure(e) =>
                   logger.error(e.toString.trim)
-                  Future.successful(Redirect("https://yahoo.com"))
+                  Future.successful(Redirect("https://winkie.app/failure"))
               })
               .recoverError
         )

--- a/backend/test/controllers/bot/InstallSpec.scala
+++ b/backend/test/controllers/bot/InstallSpec.scala
@@ -31,7 +31,7 @@ class BotControllerInstallSpec
             val path = "/bot?code=" + code + "&bot_id=" + botId
             val res  = Request.get(path).unsafeExec
 
-            assert(redirectLocation(res) === Some("https://google.com"))
+            assert(redirectLocation(res) === Some("https://winkie.app/success"))
             verify(uc).exec(*)
             reset(uc)
           }
@@ -45,7 +45,7 @@ class BotControllerInstallSpec
             val path = "/bot?code=" + code + "&bot_id=" + botId
             val res  = Request.get(path).unsafeExec
 
-            assert(redirectLocation(res) === Some("https://yahoo.com"))
+            assert(redirectLocation(res) === Some("https://winkie.app/failure"))
             verify(uc).exec(*)
             reset(uc)
           }


### PR DESCRIPTION
## 機能概要
リダイレクト先のurlを正式なものに変更(wixのやつに飛びます)

## レビュー優先度
最速

## その他
失敗時
<img width="896" alt="スクリーンショット 2021-04-02 10 49 13" src="https://user-images.githubusercontent.com/49926335/113371357-136f2180-93a1-11eb-8737-bb7965973c97.png">

成功時
<img width="1790" alt="スクリーンショット 2021-04-02 10 50 52" src="https://user-images.githubusercontent.com/49926335/113371434-4d402800-93a1-11eb-8196-88334d80849b.png">

